### PR TITLE
MBX-17 - fixed the filter selection bug finally

### DIFF
--- a/app/src/main/java/com/example/munchbox/MainScreen.kt
+++ b/app/src/main/java/com/example/munchbox/MainScreen.kt
@@ -34,11 +34,14 @@ import com.example.munchbox.controller.Meal
 import com.example.munchbox.data.DataSource
 import com.example.munchbox.data.DataSource.campusPizza
 import com.example.munchbox.data.DataSource.campusPizzaMeal
+import com.example.munchbox.data.DataSource.campusPizzaMeal2
 import com.example.munchbox.data.DataSource.lazeez
 import com.example.munchbox.data.DataSource.lazeezMeal
+import com.example.munchbox.data.DataSource.lazeezMeal2
 import com.example.munchbox.data.DataSource.pickUpOptions
 import com.example.munchbox.data.DataSource.shawaramaPlus
 import com.example.munchbox.data.DataSource.shawarmaPlusMeal
+import com.example.munchbox.data.DataSource.shawarmaPlusMeal2
 import com.example.munchbox.ui.LoginScreen
 import com.example.munchbox.ui.MealOrderSummaryScreen
 import com.example.munchbox.ui.MealPaymentScreen
@@ -113,9 +116,9 @@ fun MunchBoxApp(
      */
     var orderedMeals by remember { mutableStateOf(listOf<Meal>()) }
 
-    lazeez.addMeals(setOf(lazeezMeal))
-    shawaramaPlus.addMeals(setOf(shawarmaPlusMeal))
-    campusPizza.addMeals(setOf(campusPizzaMeal))
+    lazeez.addMeals(setOf(lazeezMeal, lazeezMeal2))
+    shawaramaPlus.addMeals(setOf(shawarmaPlusMeal, shawarmaPlusMeal2))
+    campusPizza.addMeals(setOf(campusPizzaMeal, campusPizzaMeal2))
 
 
     Scaffold(

--- a/app/src/main/java/com/example/munchbox/data/FakeDataSource.kt
+++ b/app/src/main/java/com/example/munchbox/data/FakeDataSource.kt
@@ -20,10 +20,13 @@ object DataSource {
     var campusPizza = Restaurant(name="Campus Pizza", setOf(), imageID = R.drawable.campuspizza)
     var shawaramaPlus = Restaurant(name="Shawarma Plus", setOf(), imageID = R.drawable.shawarmaplus)
 
-    val lazeezMeal = Meal(setOf(DietaryOption.VEGE, DietaryOption.GF, DietaryOption.HALAL, DietaryOption.MEAT), lazeez, setOf(DayOfWeek.SUNDAY))
+    val lazeezMeal = Meal(setOf(DietaryOption.VEGE, DietaryOption.GF), lazeez, setOf(DayOfWeek.SUNDAY))
+    val lazeezMeal2 = Meal(setOf(DietaryOption.HALAL, DietaryOption.MEAT), lazeez, setOf(DayOfWeek.SUNDAY))
     val campusPizzaMeal =  Meal(setOf(DietaryOption.VEGE, DietaryOption.GF, DietaryOption.HALAL, DietaryOption.MEAT), campusPizza, setOf(DayOfWeek.TUESDAY))
-    val shawarmaPlusMeal =  Meal(setOf(DietaryOption.VEGE, DietaryOption.GF, DietaryOption.HALAL, DietaryOption.MEAT), shawaramaPlus, setOf(DayOfWeek.WEDNESDAY))
+    val campusPizzaMeal2 =  Meal(setOf(DietaryOption.GF), campusPizza, setOf(DayOfWeek.TUESDAY))
+    val shawarmaPlusMeal =  Meal(setOf(DietaryOption.HALAL, DietaryOption.MEAT), shawaramaPlus, setOf(DayOfWeek.SUNDAY))
+    val shawarmaPlusMeal2 =  Meal(setOf(DietaryOption.VEGE, DietaryOption.GF, DietaryOption.HALAL), shawaramaPlus, setOf(DayOfWeek.WEDNESDAY))
 
-    val allMeals = setOf(lazeezMeal, campusPizzaMeal, shawarmaPlusMeal)
+    val allMeals = setOf(lazeezMeal, lazeezMeal2, campusPizzaMeal, campusPizzaMeal2, shawarmaPlusMeal, shawarmaPlusMeal2)
     val pickUpOptions = setOf(DayOfWeek.TUESDAY)
 }

--- a/app/src/main/java/com/example/munchbox/ui/components/OrderSummaryCard.kt
+++ b/app/src/main/java/com/example/munchbox/ui/components/OrderSummaryCard.kt
@@ -21,11 +21,15 @@ fun OrderSummaryCard(meal: Meal){
         restaurant = meal.restaurant,
         allMeals = setOf(meal),
         onAdd = { null },
-        added = meal.options,
+        onSelectOption = { null },
+        selectedOptions = meal.options,
+        availableOptions = meal.options,
+        added = true,
         disabled = true,
         modifier = Modifier
             .fillMaxWidth()
             .padding(25.dp)
+
     )
 }
 @Preview


### PR DESCRIPTION
Major changes to the Meal Card:
* It's now completely stateless

The actual bug fix:
* You can trigger a state re-render based on other state variables by adding arguments to the `remember` keyword

Some other stuff included in here:
* I made the behaviour of adding and deselecting meals from your order a little cleaner by disabling other cards when you have a full order, and disabling selection of other filters on cards that are disabled or selected.